### PR TITLE
Ensure db with *exact* name supplied exists

### DIFF
--- a/manifests/db.pp
+++ b/manifests/db.pp
@@ -10,6 +10,6 @@ define postgresql::db($ensure = present) {
       $name
     ], ' '),
     require => Exec['wait-for-postgresql'],
-    unless  => "psql -aA -p${postgresql::config::port} -l | grep ${name}"
+    unless  => "psql -aA -p${postgresql::config::port} -l | grep ' ${name} '"
   }
 }


### PR DESCRIPTION
Currently, if I have a DB named `activerecord_unittest2`, and want `activerecord_unittest` to be created as well...

``` puppet
postgresql::db { 'activerecord_unittest': }
postgresql::db { 'activerecord_unittest2': }
```

It will likely create `activerecord_unittest2`, then attempt to check if `activerecord_unittest` exists by just greping `activerecord_unittest`. This string is actually a substring of `activerecord_unittest2` so it will make the function NOT create `activerecord_unittest`, even if it doesn't exist.

This PR fixed that by checking if the DB name being checked is wrapped by spaces from both sides.
