### PR TITLE
bump to v9.2.4, closes boxen/puppet-postgresql#9

### DIFF
--- a/files/brews/postgresql.rb
+++ b/files/brews/postgresql.rb
@@ -2,9 +2,9 @@ require 'formula'
 
 class Postgresql < Formula
   homepage 'http://www.postgresql.org/'
-  url 'http://ftp.postgresql.org/pub/source/v9.1.4/postgresql-9.1.4.tar.bz2'
-  sha1 'c75fd5696af02a275a104260eac8b3a4abe35682'
-  version '9.1.4-boxen2'
+  url 'http://ftp.postgresql.org/pub/source/v9.2.4/postgresql-9.2.4.tar.bz2'
+  sha1 '75b53c884cb10ed9404747b51677358f12082152'
+  version '9.2.4-boxen1'
 
   depends_on 'ossp-uuid'
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -30,7 +30,7 @@ class postgresql {
   }
 
   package { 'boxen/brews/postgresql':
-    ensure => '9.1.4-boxen2',
+    ensure => '9.2.4-boxen1',
     notify => Service['dev.postgresql']
   }
 


### PR DESCRIPTION
As per request for most recent version, as @wfarr says, "Should be as
simple as a version bump + sha fix."

This module still really needs tests, but someone who cares more about
postgres than me will have to take care of that.
