### PR TITLE
Fix the postgres db name matching

### DIFF
--- a/manifests/db.pp
+++ b/manifests/db.pp
@@ -10,6 +10,6 @@ define postgresql::db($ensure = present) {
       $name
     ], ' '),
     require => Exec['wait-for-postgresql'],
-    unless  => "psql -aA -p${postgresql::config::port} -l | grep ' ${name} '"
+    unless  => "psql -aA -p${postgresql::config::port} -l | grep '${name}'"
   }
 }


### PR DESCRIPTION
Looks like issue #17 has affected and been fixed in the same way by others: https://github.com/philtr/puppet-postgresql/commit/6d17f98a9fdb51b084009a0738339cae1d1b2837
