### PR TITLE
Kill stale pidfiles before starting the service

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -16,6 +16,7 @@ class postgresql::service(
   }
 
   $nc = "nc -z ${host} ${port}"
+  $pidfile = "${datadir}/postmaster.pid"
 
   if $::operatingsystem == 'Darwin' {
     service { 'com.boxen.postgresql':
@@ -28,6 +29,13 @@ class postgresql::service(
   exec { 'init-postgresql-db':
     command => "initdb -E UTF-8 ${datadir}",
     creates => "${datadir}/PG_VERSION",
+  }
+
+  ->
+  exec { 'kill-stale-postgres-pidfile':
+    # Remove the pidfile, unless there's a postgres process running
+    command => "rm -f ${pidfile}",
+    unless  => "ps -p `head -1 ${pidfile}` | grep postgres",
   }
 
   ->


### PR DESCRIPTION
If you kill postgres badly, it leaves a `postmaster.pid` file lying around which prevents the service from starting later. This gets in the way of development, causes confusion, and _burns battery_ as launchd tries again and again to start postgres.

There are potential consequences to this in the case of a corrupt database, but they're so unlikely that I much prefer to err on the side of convenience for a developer machine.
