### PR TITLE
Add role creation support

### DIFF
--- a/manifests/db.pp
+++ b/manifests/db.pp
@@ -9,7 +9,10 @@ define postgresql::db (
 ) {
   require postgresql
 
-  $db_owner = $db_owner ? { undef => $postgresql::user, default => $owner }
+  $db_owner = $owner ? {
+    undef   => $postgresql::user,
+    default => $owner
+  }
 
   exec { "postgresql-db-${name}":
     command => join([

--- a/manifests/db.pp
+++ b/manifests/db.pp
@@ -3,17 +3,20 @@
 # Usage:
 #
 #     postgresql::db { 'mydb': }
-define postgresql::db(
-  $ensure = present
+define postgresql::db (
+  $ensure = present,
+  $owner = undef
 ) {
   require postgresql
+
+  $db_owner = $db_owner ? { undef => $postgresql::user, default => $owner }
 
   exec { "postgresql-db-${name}":
     command => join([
       'createdb',
       "-p${postgresql::port}",
       '-E UTF-8',
-      "-O ${postgresql::user}",
+      "-O ${db_owner}",
       $name
     ], ' '),
     unless  => "psql -aA -p${postgresql::port} -t -l | cut -d \\| -f 1 | grep -w '${name}'"

--- a/manifests/role.pp
+++ b/manifests/role.pp
@@ -3,8 +3,10 @@
 # Usage:
 #
 #     postgresql::role { 'rolename': }
-define postgres::role (
-  $password_hash    = false,
+define postgresql::role (
+  $ensure           = present,
+  $username         = $name,
+  $password         = undef,
   $createdb         = false,
   $createrole       = false,
   $login            = true,
@@ -12,17 +14,28 @@ define postgres::role (
   $superuser        = false,
   $replication      = false,
   $connection_limit = '-1',
-  $username         = $name
 ) {
   require postgresql
-  notify { "Creating user ${$username}": }
+
+  $createdb_sql    = $createdb    ? { true => 'CREATEDB',    default => 'NOCREATEDB' }
+  $createrole_sql  = $createrole  ? { true => 'CREATEROLE',  default => 'NOCREATEROLE' }
+  $login_sql       = $login       ? { true => 'LOGIN',       default => 'NOLOGIN' }
+  $inherit_sql     = $inherit     ? { true => 'INHERIT',     default => 'NOINHERIT' }
+  $superuser_sql   = $superuser   ? { true => 'SUPERUSER',   default => 'NOSUPERUSER' }
+  $replication_sql = $replication ? { true => 'REPLICATION', default => '' }
+
+  if ($password != undef) {
+    $password_sql = "ENCRYPTED PASSWORD '${password}'"
+  } else {
+    $password_sql = ''
+  }
 
   exec { "postgresql-createuser-${name}":
     command => join([
-    'createuser',
-    "-p${postgresql::port}",
-    $username
+      'psql',
+      "-p${postgresql::port}",
+      "-c \"CREATE ROLE \"${username}\" ${password_sql} ${login_sql} ${createrole_sql} ${createdb_sql} ${superuser_sql} ${replication_sql} CONNECTION LIMIT ${connection_limit}\""
     ], ' '),
-    unless  => "psql -aA -p${postgresql::port} -t -l | tail +2 | grep -w '${username}'"
+    unless  => "psql -aA -p${postgresql::port} -t -c \"SELECT rolname FROM pg_roles WHERE rolname='${username}'\" | tail +2 | grep ${username}"
   }
 }

--- a/manifests/role.pp
+++ b/manifests/role.pp
@@ -1,0 +1,28 @@
+# Creates a new postgresql role
+#
+# Usage:
+#
+#     postgresql::role { 'rolename': }
+define postgres::role (
+  $password_hash    = false,
+  $createdb         = false,
+  $createrole       = false,
+  $login            = true,
+  $inherit          = true,
+  $superuser        = false,
+  $replication      = false,
+  $connection_limit = '-1',
+  $username         = $name
+) {
+  require postgresql
+  notify { "Creating user ${$username}": }
+
+  exec { "postgresql-createuser-${name}":
+    command => join([
+    'createuser',
+    "-p${postgresql::port}",
+    $username
+    ], ' '),
+    unless  => "psql -aA -p${postgresql::port} -t -l | tail +2 | grep -w '${username}'"
+  }
+}

--- a/spec/defines/postgresql_db_spec.rb
+++ b/spec/defines/postgresql_db_spec.rb
@@ -6,10 +6,25 @@ describe "postgresql::db" do
 
   it do
     should include_class("postgresql")
+  end
 
-    should contain_exec("postgresql-db-#{title}").with({
-      :command => "createdb -p15432 -E UTF-8 -O testuser #{title}",
-      :unless  => "psql -aA -p15432 -t -l | cut -d \\| -f 1 | grep -w '#{title}'"
-    })
+  context "without a specified db owner" do
+    it do
+      should contain_exec("postgresql-db-#{title}").with({
+        :command => "createdb -p15432 -E UTF-8 -O testuser #{title}",
+        :unless  => "psql -aA -p15432 -t -l | cut -d \\| -f 1 | grep -w '#{title}'"
+      })
+    end
+  end
+
+  context "with a specified db owner" do
+    let(:params) { { :owner => 'foo' } }
+
+    it do
+      should contain_exec("postgresql-db-#{title}").with({
+        :command => "createdb -p15432 -E UTF-8 -O foo #{title}",
+        :unless  => "psql -aA -p15432 -t -l | cut -d \\| -f 1 | grep -w '#{title}'"
+      })
+    end
   end
 end


### PR DESCRIPTION
A shameless rip from the Puppet PostgreSQL module that allows us to create roles with Boxen. As a follow on I also allowed users to specify which role owns a database when it's being created with `postgresql::db`