### PR TITLE
Don't assume homebrew is in boxen::config::home

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -5,7 +5,7 @@ class postgresql::params {
     Darwin: {
       include boxen::config
 
-      $executable = "${boxen::config::home}/homebrew/bin/postgres"
+      $executable = "${boxen::config::homebrewdir}/bin/postgres"
       $datadir    = "${boxen::config::datadir}/postgresql-9.3"
       $logdir     = "${boxen::config::logdir}/postgresql-9.3"
       $port       = 15432


### PR DESCRIPTION
We have a config var for it; use it.
