### PR TITLE
Fix search for existing databases by removing no-align option

### DIFF
--- a/manifests/db.pp
+++ b/manifests/db.pp
@@ -16,6 +16,6 @@ define postgresql::db(
       "-O ${postgresql::user}",
       $name
     ], ' '),
-    unless  => "${postgresql::bindir}/psql -aA -p${postgresql::port} -t -l | cut -d \\| -f 1 | grep -w '${name}'"
+    unless  => "${postgresql::bindir}/psql -a -p${postgresql::port} -t -l | cut -d \\| -f 1 | grep -w '${name}'"
   }
 }

--- a/spec/defines/postgresql_db_spec.rb
+++ b/spec/defines/postgresql_db_spec.rb
@@ -9,7 +9,7 @@ describe "postgresql::db" do
 
     should contain_exec("postgresql-db-#{title}").with({
       :command => "/test/boxen/homebrew/bin/createdb -p15432 -E UTF-8 -O testuser #{title}",
-      :unless  => "/test/boxen/homebrew/bin/psql -aA -p15432 -t -l | cut -d \\| -f 1 | grep -w '#{title}'"
+      :unless  => "/test/boxen/homebrew/bin/psql -a -p15432 -t -l | cut -d \\| -f 1 | grep -w '#{title}'"
     })
   end
 end


### PR DESCRIPTION
This command returns a list of database names that match the grep query. With the -A (no-align) option, the list of databases is incorrectly chomped on line breaks so that it appears that there are more database name matches than actually exist. Removing the -A option from this psql command appears to fix the problem. 