### PR TITLE
Update 3.x to run db commands from the right dir

### DIFF
--- a/manifests/db.pp
+++ b/manifests/db.pp
@@ -10,12 +10,12 @@ define postgresql::db(
 
   exec { "postgresql-db-${name}":
     command => join([
-      'createdb',
+      "${postgresql::bindir}/createdb",
       "-p${postgresql::port}",
       '-E UTF-8',
       "-O ${postgresql::user}",
       $name
     ], ' '),
-    unless  => "psql -aA -p${postgresql::port} -t -l | cut -d \\| -f 1 | grep -w '${name}'"
+    unless  => "${postgresql::bindir}/psql -aA -p${postgresql::port} -t -l | cut -d \\| -f 1 | grep -w '${name}'"
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -6,6 +6,7 @@
 class postgresql(
   $ensure     = $postgresql::params::ensure,
 
+  $bindir     = $postgresql::params::bindir,
   $executable = $postgresql::params::executable,
 
   $host       = $postgresql::params::host,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -5,7 +5,8 @@ class postgresql::params {
     Darwin: {
       include boxen::config
 
-      $executable = "${boxen::config::homebrewdir}/bin/postgres"
+      $bindir     = "${boxen::config::homebrewdir}/bin"
+      $executable = "${bindir}/postgres"
       $datadir    = "${boxen::config::datadir}/postgresql-9.3"
       $logdir     = "${boxen::config::logdir}/postgresql-9.3"
       $port       = 15432
@@ -20,6 +21,7 @@ class postgresql::params {
 
     Ubuntu: {
       $executable = undef # only used on Darwin
+      $bindir     = '/usr/bin'
       $datadir    = '/var/lib/postgresql'
       $logdir     = '/var/log/postgresql'
       $port       = 5432

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -5,6 +5,7 @@ class postgresql::service(
   $service = $postgresql::params::service,
   $enable  = $postgresql::params::enable,
 
+  $bindir  = $postgresql::params::bindir,
   $datadir = $postgresql::params::datadir,
   $host    = $postgresql::params::host,
   $port    = $postgresql::params::port,
@@ -27,7 +28,7 @@ class postgresql::service(
   }
 
   exec { 'init-postgresql-db':
-    command => "initdb -E UTF-8 ${datadir}",
+    command => "${bindir}/initdb -E UTF-8 ${datadir}",
     creates => "${datadir}/PG_VERSION",
   }
 

--- a/spec/defines/postgresql_db_spec.rb
+++ b/spec/defines/postgresql_db_spec.rb
@@ -8,8 +8,8 @@ describe "postgresql::db" do
     should include_class("postgresql")
 
     should contain_exec("postgresql-db-#{title}").with({
-      :command => "createdb -p15432 -E UTF-8 -O testuser #{title}",
-      :unless  => "psql -aA -p15432 -t -l | cut -d \\| -f 1 | grep -w '#{title}'"
+      :command => "/test/boxen/homebrew/bin/createdb -p15432 -E UTF-8 -O testuser #{title}",
+      :unless  => "/test/boxen/homebrew/bin/psql -aA -p15432 -t -l | cut -d \\| -f 1 | grep -w '#{title}'"
     })
   end
 end


### PR DESCRIPTION
This pull request adds to the 3.x branch (master) the same fixes made to the 2.x branch in #34 (plus [this commit](https://github.com/boxen/puppet-postgresql/commit/5c9d112ea7940e29e27f3db3f535eab74bbed4ac)) so that this module is compatible with the use of a custom homebrew location.

I would be keen to see a new 3.x release after this has been merged. Please :smile: 