### PR TITLE
Fish Compatibility

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -35,6 +35,12 @@ class postgresql::config(
   if $::operatingsystem == 'Darwin' {
     include boxen::config
 
+    boxen::env_script { 'postgresql-fish':
+      content   => template('postgresql/env.fish.erb'),
+      priority  => 'lower',
+      extension => 'fish',
+    }
+
     boxen::env_script { 'postgresql':
       content  => template('postgresql/env.sh.erb'),
       priority => 'lower',

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -36,9 +36,10 @@ class postgresql::config(
     include boxen::config
 
     boxen::env_script { 'postgresql-fish':
-      content   => template('postgresql/env.fish.erb'),
-      priority  => 'lower',
-      extension => 'fish',
+      content    => template('postgresql/env.fish.erb'),
+      priority   => 'lower',
+      scriptname => 'postgresql',
+      extension  => 'fish',
     }
 
     boxen::env_script { 'postgresql':

--- a/templates/env.fish.erb
+++ b/templates/env.fish.erb
@@ -1,0 +1,10 @@
+# Postgres config vars
+
+set -gx BOXEN_POSTGRESQL_HOST <%= @host %>
+set -gx BOXEN_POSTGRESQL_PORT <%= @port %>
+set -gx BOXEN_POSTGRESQL_URL "postgres://$BOXEN_POSTGRESQL_HOST:$BOXEN_POSTGRESQL_PORT/"
+
+# soft global overrides
+if [ -z PGPORT ]
+  set -gx PGPORT $BOXEN_POSTGRESQL_PORT
+end


### PR DESCRIPTION
Adds a Fish version of the env script. 

Relies on boxen/puppet-boxen#138 (for the `extension` argument to `env_script`).
