### PR TITLE
Upgrade to PG 9.5.2

### DIFF
--- a/files/brews/postgresql.rb
+++ b/files/brews/postgresql.rb
@@ -1,23 +1,14 @@
 class Postgresql < Formula
   desc "Object-relational database system"
   homepage "https://www.postgresql.org/"
-  revision 2
-
-  stable do
-    url "https://ftp.postgresql.org/pub/source/v9.4.5/postgresql-9.4.5.tar.bz2"
-    sha256 "b87c50c66b6ea42a9712b5f6284794fabad0616e6ae420cf0f10523be6d94a39"
-  end
+  url "https://ftp.postgresql.org/pub/source/v9.5.2/postgresql-9.5.2.tar.bz2"
+  sha256 "f8d132e464506b551ef498719f18cfe9d777709c7a1589dc360afc0b20e47c41"
 
   bottle do
-    sha256 "b57a3b65cd90917273d754f2625a83e69eac78aeff5b79573f8ac9811bdf643c" => :el_capitan
-    sha256 "6b26ad24a228620e16d7f81b4f3bd183a80e1c2f02b8505a1a6b71356eec53a4" => :yosemite
-    sha256 "a6a49e234543bb7c4fb33b64dd14b48da5b8373fb2110d62e82d7129997f4926" => :mavericks
-  end
-
-  devel do
-    url "https://ftp.postgresql.org/pub/source/v9.5beta1/postgresql-9.5beta1.tar.bz2"
-    sha256 "b53199e2667982de2039ad7e30467f67c5d7af678e69d6211de8ba1cac75c9f0"
-    version "9.5beta1"
+    revision 1
+    sha256 "12bc2c22b06aaa82f577c14a667805a6e8aed9065a3a376e324393afdf6b62f0" => :el_capitan
+    sha256 "5e7ee10a23edb6ee985f49a969894133939a20eaeee2f2841cb8be82c2f79c74" => :yosemite
+    sha256 "e6673530167899750d5f2eaaebe53e7ff8b10caada449aef39d66a1af39cfe49" => :mavericks
   end
 
   option "32-bit"
@@ -46,7 +37,7 @@ class Postgresql < Formula
     ENV.libxml2 if MacOS.version >= :snow_leopard
 
     ENV.prepend "LDFLAGS", "-L#{Formula["openssl"].opt_lib} -L#{Formula["readline"].opt_lib}"
-    ENV.prepend "CPPLAGS", "-I#{Formula["openssl"].opt_include} -I#{Formula["readline"].opt_include}"
+    ENV.prepend "CPPFLAGS", "-I#{Formula["openssl"].opt_include} -I#{Formula["readline"].opt_include}"
 
     args = %W[
       --disable-debug
@@ -93,7 +84,8 @@ class Postgresql < Formula
   end
 
   def post_install
-    unless File.exist? "#{var}/postgres"
+    (var/"postgres").mkpath
+    unless File.exist? "#{var}/postgres/PG_VERSION"
       system "#{bin}/initdb", "#{var}/postgres"
     end
   end
@@ -103,8 +95,14 @@ class Postgresql < Formula
     you may need to remove the previous version first. See:
       https://github.com/Homebrew/homebrew/issues/2510
 
-    To migrate existing data from a previous major version (pre-9.4) of PostgreSQL, see:
-      https://www.postgresql.org/docs/9.4/static/upgrading.html
+    To migrate existing data from a previous major version (pre-9.0) of PostgreSQL, see:
+      https://www.postgresql.org/docs/9.5/static/upgrading.html
+
+    To migrate existing data from a previous minor version (9.0-9.4) of PosgresSQL, see:
+      https://www.postgresql.org/docs/9.5/static/pgupgrade.html
+
+      You will need your previous PostgreSQL installation from brew to perform `pg_upgrade`.
+      Do not run `brew cleanup postgresql` until you have performed the migration.
     EOS
   end
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -7,12 +7,12 @@ class postgresql::params {
 
       $bindir     = "${boxen::config::homebrewdir}/bin"
       $executable = "${bindir}/postgres"
-      $datadir    = "${boxen::config::datadir}/postgresql-9.4"
-      $logdir     = "${boxen::config::logdir}/postgresql-9.4"
+      $datadir    = "${boxen::config::datadir}/postgresql-9.5"
+      $logdir     = "${boxen::config::logdir}/postgresql-9.5"
       $port       = 15432
 
       $package    = 'boxen/brews/postgresql'
-      $version    = '9.4.5_2'
+      $version    = '9.5.2'
 
       $service    = 'dev.postgresql'
 

--- a/spec/classes/postgresql__config_spec.rb
+++ b/spec/classes/postgresql__config_spec.rb
@@ -6,7 +6,7 @@ describe 'postgresql::config' do
   it do
     should include_class('boxen::config')
 
-    %w(data/postgresql-9.4 log/postgresql-9.4).each do |d|
+    %w(data/postgresql-9.5 log/postgresql-9.5).each do |d|
       should contain_file("/test/boxen/#{d}").with_ensure(:directory)
     end
 

--- a/spec/classes/postgresql__service_spec.rb
+++ b/spec/classes/postgresql__service_spec.rb
@@ -6,7 +6,7 @@ describe "postgresql::service" do
   it do
     should contain_service("com.boxen.postgresql").with_ensure(:stopped)
 
-    should contain_exec("init-postgresql-db").with_creates("/test/boxen/data/postgresql-9.4/PG_VERSION")
+    should contain_exec("init-postgresql-db").with_creates("/test/boxen/data/postgresql-9.5/PG_VERSION")
     should contain_service("dev.postgresql").with_ensure(:running)
     should contain_exec("wait-for-postgresql").with_unless("nc -z 127.0.0.1 15432")
   end


### PR DESCRIPTION
This PR contains the an updated homebrew formula for PostgreSQL 9.5.2. Might be a useful to others looking to experiment with jsonb, upsert, etc. The brew formula is exactly what is present in [homebrew](https://github.com/Homebrew/homebrew-core/blob/master/Formula/postgresql.rb).

(Specs pass on ruby 2.0.0, but running under 2.2 and 2.3 is not compatible with the `json v1.8.1` included in the Gemfile.lock.)